### PR TITLE
Change camelCase custom content metadata keys to strings

### DIFF
--- a/ConvivaIntegration/components/ConvivaAnalyticsTask.brs
+++ b/ConvivaIntegration/components/ConvivaAnalyticsTask.brs
@@ -169,7 +169,7 @@ sub buildContentMetadata()
   m.contentMetadataBuilder.callFunc("setStreamType", m.top.player.callFunc("isLive"))
 
   internalCustomTags = {
-    integrationVersion: "1.0.0"
+    "integrationVersion": "1.0.0"
   }
 
   config = m.top.player.callFunc("getConfig")

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ contentMetadataOverrides = {
   playerName: "Conviva Integration Test Channel",
   viewerId: "MyAwesomeViewerId",
   tags: {
-    CustomKey: "CustomValue"
+    "CustomKey": "CustomValue"
   }
 }
 m.convivaAnalytics.callFunc("updateContentMetadata", contentMetadataOverrides)


### PR DESCRIPTION
## Problem
When using non string keys for custom content metadata they will be lowercase.

## Solution
Use strings to ensure casing