### PR TITLE
Fix error handling for VSF

### DIFF
--- a/ConvivaIntegration/components/ConvivaAnalyticsTask.brs
+++ b/ConvivaIntegration/components/ConvivaAnalyticsTask.brs
@@ -9,9 +9,9 @@ sub init()
   m.contentMetadataBuilder = CreateObject("roSGNode", "ContentMetadataBuilder")
 
   ' Workaround for wrong event order of the bitmovinPlayerSDK
-  ' The SourceUnloaded event is fired before the Error event in case of an error.
-  ' This lead to a clean session closing instead of an error. To Workaround this we delay the onSourceUnloaded event by
-  ' 100 ms
+  ' In case of an error the resulting SourceUnloaded event is fired before the actual Error event.
+  ' This leads to a clean session closing instead of an error. To work around this we delay the onSourceUnloaded event
+  ' by 100 ms
   m.sourceUnloadedTimer = invalid
 end sub
 

--- a/ConvivaIntegration/components/ConvivaAnalyticsTask.brs
+++ b/ConvivaIntegration/components/ConvivaAnalyticsTask.brs
@@ -7,6 +7,12 @@ sub init()
   m.video = invalid
 
   m.contentMetadataBuilder = CreateObject("roSGNode", "ContentMetadataBuilder")
+
+  ' Workaround for wrong event order of the bitmovinPlayerSDK
+  ' The SourceUnloaded event is fired before the Error event in case of an error.
+  ' This lead to a clean session closing instead of an error. To Workaround this we delay the onSourceUnloaded event by
+  ' 100 ms
+  m.sourceUnloadedTimer = invalid
 end sub
 
 sub internalInit()
@@ -70,6 +76,11 @@ sub monitorVideo()
         invoke(data)
       end if
     end if
+
+    if m.sourceUnloadedTimer <> invalid and m.sourceUnloadedTimer.TotalMilliseconds() > 100
+      m.sourceUnloadedTimer = invalid
+      endSession()
+    end if
   end while
 end sub
 
@@ -93,22 +104,13 @@ end sub
 
 sub onStateChanged(state)
   debugLog("[ConvivaAnalytics] state changed: " + state)
-  if state = "error"
-    onError()
-  else if state = "finished"
+  if state = "finished"
     onPlaybackFinished()
   end if
   ' Other states are handled by conviva
 end sub
 
 sub onPlaybackFinished()
-  endSession()
-end sub
-
-sub onError()
-  ' create a new session to track VSF
-  if not isSessionActive() then createSession()
-  m.livePass.reportError(m.cSession, "Error", m.livePass.StreamerError.SEVERITY_FATAL)
   endSession()
 end sub
 
@@ -131,7 +133,11 @@ sub onSeek()
 end sub
 
 sub onSourceUnloaded()
-  endSession()
+  debugLog("[Player Event] onSourceUnloaded")
+  if not isSessionActive() then return
+
+  m.sourceUnloadedTimer = CreateObject("roTimespan")
+  m.sourceUnloadedTimer.mark() ' start the timer
 end sub
 
 sub createConvivaSession()

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Currently we don't support ad tracking.
 
 ## Compatibility
-**This version of the Conviva Analytics Integration works only with Bitmovin Player Version >= 1.4.x.
+**This version of the Conviva Analytics Integration works only with Bitmovin Player Version >= 1.7.x.
 The recommended version of the Conviva SDK is 2.151.0.36978.**
 
 ## Getting Started

--- a/demo/components/playerExample/PlayerExample.brs
+++ b/demo/components/playerExample/PlayerExample.brs
@@ -4,7 +4,7 @@ sub init()
   ' Creates the ComponentLibrary (the BitmovinPlayerSDK in this case)
   m.bitmovinPlayerSDK = CreateObject("roSGNode", "ComponentLibrary")
   m.bitmovinPlayerSDK.id = "BitmovinPlayerSDK"
-  m.bitmovinPlayerSDK.uri = "https://cdn.bitmovin.com/player/roku/1.4.0-b.4/bitmovinplayer.zip"
+  m.bitmovinPlayerSDK.uri = "https://cdn.bitmovin.com/player/roku/1.7.0-b.1/bitmovinplayer.zip"
 
   ' Adding the ComponentLibrary node to the scene will start the download of the library
   m.top.appendChild(m.bitmovinPlayerSDK)

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "watch": {
     "build:component": {
       "patterns": [
-        "./ConvivaIntegration/components/*.*"
+        "./ConvivaIntegration/components/**/*.*"
       ],
       "extensions": "brs,xml"
     },
     "build:example": {
       "patterns": [
-        "./ConvivaIntegration/components/*.*"
+        "./ConvivaIntegration/components/**/*.*"
       ],
       "extensions": "brs,xml"
     }


### PR DESCRIPTION
## Description
We weren't able to track VSF due to two issues:
- Wrong event handler handling within the player
- Wrong event order from the player

## Solution
- Wrong event handling was fixed in player 1.7 so update to this version fixed issue one
- Delay the `onSourceUnloaded` event by 100 ms to give the error state a change to be tracked before closing the session.